### PR TITLE
Fix params typing for blog post page

### DIFF
--- a/src/app/updates/[date]/page.tsx
+++ b/src/app/updates/[date]/page.tsx
@@ -5,8 +5,8 @@ import { supabase } from "@/lib/supabase"
 
 const FALLBACKS = ["/jpg/post.jpg", "/jpg/post1.jpg", "/jpg/post2.jpg", "/jpg/post3.jpg"]
 
-export default async function Page({ params }: { params: Promise<{ date: string }> }) {
-  const { date } = await params
+export default async function Page({ params }: { params: { date: string } }) {
+  const { date } = params
 
   try {
     // First, get the post data


### PR DESCRIPTION
## Summary
- fix incorrect params type in blog post route

## Testing
- `npx tsc --noEmit` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_685d9270b97c832a83c095c808cb98ef